### PR TITLE
Add argument parser for Flask app port configuration

### DIFF
--- a/run.py
+++ b/run.py
@@ -7,6 +7,7 @@ import re
 import socket
 import time
 import urllib.parse
+import argparse
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 import dns.resolver
@@ -780,4 +781,10 @@ def generate_m3u():
 
 
 if __name__ == "__main__":
-    app.run(debug=True, host="0.0.0.0")
+    parser = argparse.ArgumentParser(description="Run the Flask app.")
+    parser.add_argument(
+        "--port", type=int, default=5000, help="Port number to run the app on"
+    )
+    args = parser.parse_args()
+
+    app.run(debug=True, host="0.0.0.0", port=args.port)


### PR DESCRIPTION
Add a command line option to specify the port where the application will be starting. Defaults to the original 5000 port.